### PR TITLE
Update audience claim in client_assertion (Private Key JWT)

### DIFF
--- a/internal/oauth2/jwt.go
+++ b/internal/oauth2/jwt.go
@@ -130,7 +130,7 @@ func ClientAssertionClaims(serverConfig ServerConfig, clientConfig ClientConfig)
 		return map[string]interface{}{
 			"iss": clientConfig.ClientID,
 			"sub": clientConfig.ClientID,
-			"aud": serverConfig.TokenEndpoint,
+			"aud": clientConfig.IssuerURL,
 			"iat": time.Now().Unix(),
 			"exp": time.Now().Add(time.Minute * 10).Unix(),
 			"jti": RandomString(20),


### PR DESCRIPTION
Updated the aud (audience) claim is constructed in client assertions (Private Key JWT) to align with the recent draft Updates to Audience Values for OAuth 2.0 Authorization Servers [draft-ietf-oauth-rfc7523bis](https://datatracker.ietf.org/doc/draft-ietf-oauth-rfc7523bis).