### PR TITLE
DEVOPS-8593: feat: auto-approve and auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,50 +1,33 @@
-name: Dependabot auto-approve
-
+name: Dependabot auto-approve and merge
 on: pull_request
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  auto-approve:
+  dependabot:
     runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.actor == 'dependabot[bot]'
-    permissions:
-      pull-requests: write
-      checks: read
-      statuses: read
-      actions: read
-      contents: read
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Verify all commits are from the bot
-        run: |
-          authors=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq '.[].author.login' | sort -u)
-          if [ "$authors" != "$BOT_LOGIN" ]; then
-            echo "::error::Refusing to auto-approve: PR contains commits not authored by ${BOT_LOGIN} (authors: ${authors})"
-            exit 1
-          fi
-        env:
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BOT_LOGIN: dependabot[bot]
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Wait for required checks to pass
-        timeout-minutes: 30
-        run: |
-          set +e
-          output=$(gh pr checks "$PR_URL" --required --watch --fail-fast 2>&1)
-          code=$?
-          set -e
-          echo "$output"
-          if [ $code -ne 0 ] && echo "$output" | grep -qi "no required checks"; then
-            echo "No required checks configured on the base branch; skipping wait."
-            exit 0
-          fi
-          exit $code
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Approve the PR
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR - dependabot
         run: gh pr review --approve "$PR_URL"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Second approval - golang deps only
+        if: steps.metadata.outputs.package-ecosystem == 'go_modules'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

Replaces the wait-and-approve workflow with the pattern ciam-core uses ([their workflow](https://github.com/SecureAuthCorp/ciam-core/blob/dev/.github/workflows/dependabot-auto-approve.yaml)): approve the Dependabot PR, add a second approval from the DevOps service account for Go module updates, and enable GitHub native auto-merge (squash). Auto-merge only completes once branch protection is satisfied, so no explicit check-watching is needed — this also sidesteps the `gh pr checks` limitations on Dependabot tokens entirely.

Differences from ciam-core's version: the Slack failure notification is omitted (it targets a ciam team channel with their bot token).

Note: the second-approval step requires `GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1` to be available to this repo as a **Dependabot secret** — since oauth2c is public, the org secret's visibility policy must include it.

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8593