### PR TITLE
fix: send client_id on the token request when no auth method is set

### DIFF
--- a/internal/oauth2/request.go
+++ b/internal/oauth2/request.go
@@ -197,7 +197,7 @@ func (r *Request) AuthenticateClient(
 	var err error
 
 	switch cconfig.AuthMethod {
-	case NoneAuthMethod:
+	case NoneAuthMethod, "":
 		r.Form.Set("client_id", cconfig.ClientID)
 	case ClientSecretPostAuthMethod:
 		r.Form.Set("client_id", cconfig.ClientID)

--- a/internal/oauth2/request_test.go
+++ b/internal/oauth2/request_test.go
@@ -100,3 +100,51 @@ func TestRequestTokenResource(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestTokenClientID(t *testing.T) {
+	tests := map[string]struct {
+		authMethod string
+		expected   string
+	}{
+		"unset":              {authMethod: "", expected: "test-client"},
+		"none":               {authMethod: oauth2.NoneAuthMethod, expected: "test-client"},
+		"client_secret_post": {authMethod: oauth2.ClientSecretPostAuthMethod, expected: "test-client"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got url.Values
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				got, err = url.ParseQuery(string(body))
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+			}))
+			defer srv.Close()
+
+			cconfig := oauth2.ClientConfig{
+				ClientID:   "test-client",
+				GrantType:  oauth2.DeviceGrantType,
+				AuthMethod: tc.authMethod,
+			}
+			sconfig := oauth2.ServerConfig{TokenEndpoint: srv.URL}
+
+			_, _, err := oauth2.RequestToken(
+				context.Background(),
+				cconfig,
+				sconfig,
+				&http.Client{},
+				oauth2.WithDeviceCode("device-code"),
+			)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, got.Get("client_id"))
+			require.Equal(t, "device-code", got.Get("device_code"))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #160

Device flow leaves `AuthMethod` empty (`PromptForClientConfig` only asks for it on the code/client_credentials/refresh/password/jwt-bearer grants), and `AuthenticateClient` switches on `AuthMethod` — so with no auth method the token request carried only `grant_type` and `device_code`, and the server answered `invalid_client`.

Fixing it in `AuthenticateClient` covers every caller (token, PAR), not just device flow.

Before:
```
POST /token  body=device_code=DC123&grant_type=urn:ietf:params:oauth:grant-type:device_code
```
After:
```
POST /token  body=client_id=my-client&device_code=DC123&grant_type=urn:ietf:params:oauth:grant-type:device_code
```
